### PR TITLE
Fix MediaSource player race conditions

### DIFF
--- a/Front/music-flow/src/utils/mediaSourcePlayer.js
+++ b/Front/music-flow/src/utils/mediaSourcePlayer.js
@@ -1,3 +1,5 @@
+let currentAbortController = null;
+
 export async function loadWithMediaSource(audioElement, url) {
   if (!window.MediaSource || !MediaSource.isTypeSupported('audio/mpeg')) {
     audioElement.src = url;
@@ -5,9 +7,22 @@ export async function loadWithMediaSource(audioElement, url) {
     return;
   }
 
+  if (currentAbortController) {
+    currentAbortController.abort();
+  }
+
+  const abortController = new AbortController();
+  currentAbortController = abortController;
+
   return new Promise((resolve, reject) => {
     const mediaSource = new MediaSource();
     audioElement.src = URL.createObjectURL(mediaSource);
+
+    const cleanup = () => {
+      if (currentAbortController === abortController) {
+        currentAbortController = null;
+      }
+    };
 
     mediaSource.addEventListener('sourceopen', async () => {
       try {
@@ -17,6 +32,7 @@ export async function loadWithMediaSource(audioElement, url) {
         let queue = [];
         let updating = false;
         const append = (chunk) => {
+          if (abortController.signal.aborted) return;
           if (!updating) {
             updating = true;
             sourceBuffer.appendBuffer(chunk);
@@ -26,23 +42,27 @@ export async function loadWithMediaSource(audioElement, url) {
         };
 
         sourceBuffer.addEventListener('updateend', () => {
+          if (abortController.signal.aborted) return;
           updating = false;
           if (queue.length > 0) {
             append(queue.shift());
           } else if (mediaSource.readyState === 'open' && !audioElement.error) {
             mediaSource.endOfStream();
+            cleanup();
             resolve();
           }
         });
 
-        const response = await fetch(url);
+        const response = await fetch(url, { signal: abortController.signal });
         const reader = response.body.getReader();
 
         const read = async () => {
           const { done, value } = await reader.read();
+          if (abortController.signal.aborted) return;
           if (done) {
             if (!updating) {
               mediaSource.endOfStream();
+              cleanup();
               resolve();
             }
             return;
@@ -53,7 +73,10 @@ export async function loadWithMediaSource(audioElement, url) {
 
         read();
       } catch (e) {
-        reject(e);
+        cleanup();
+        if (!abortController.signal.aborted) {
+          reject(e);
+        }
       }
     });
 


### PR DESCRIPTION
## Summary
- prevent media source errors in the player by aborting prior requests when loading new audio

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687273c23d28832283725a4109b29cc5