### PR TITLE
Add room join component

### DIFF
--- a/Front/music-flow/src/components/Rooms.vue
+++ b/Front/music-flow/src/components/Rooms.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="rooms-container">
+    <input
+      v-model="roomIdInput"
+      type="text"
+      placeholder="Введите ID комнаты"
+      class="rooms-input"
+      @keyup.enter="joinRoom"
+    />
+    <Button text="Подключиться" @click="joinRoom" />
+  </div>
+</template>
+
+<script>
+import Button from '@/components/Button.vue';
+
+export default {
+  components: { Button },
+  data() {
+    return { roomIdInput: '' };
+  },
+  methods: {
+    joinRoom() {
+      const value = this.roomIdInput.trim();
+      if (value) {
+        this.$emit('join-room', value);
+      }
+    }
+  }
+};
+</script>
+
+<style scoped>
+.rooms-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  width: 100%;
+  height: 100%;
+}
+
+.rooms-input {
+  width: 100%;
+  max-width: 400px;
+  padding: 12px 20px;
+  border-radius: 50px;
+  border: none;
+  background: rgba(160, 85, 245, 0.15);
+  color: white;
+  outline: none;
+}
+</style>

--- a/Front/music-flow/src/utils/cookies.js
+++ b/Front/music-flow/src/utils/cookies.js
@@ -1,0 +1,8 @@
+export function getCookie(name) {
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) {
+    return parts.pop().split(';').shift();
+  }
+  return null;
+}

--- a/Front/music-flow/src/utils/roomConnection.js
+++ b/Front/music-flow/src/utils/roomConnection.js
@@ -1,0 +1,11 @@
+import { initSocket } from './playerSocket.js';
+import { getCookie } from './cookies.js';
+
+export function connectToRoom(roomId, onMessage) {
+  const userId = getCookie('user_id');
+  if (!userId) {
+    throw new Error('User not authorized');
+  }
+  const socket = initSocket(roomId, userId, { '*': onMessage });
+  return { socket, userId };
+}

--- a/Front/music-flow/src/views/Main.vue
+++ b/Front/music-flow/src/views/Main.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="main-container">
+  <div v-if="!connected" class="main-container">
+    <Rooms @join-room="handleJoinRoom" />
+  </div>
+  <div v-else class="main-container">
     <!-- Левый блок: Список участников -->
     <div class="participants-column">
       <ParticipantsList
@@ -24,8 +27,10 @@
     <!-- Правый блок: Плеер -->
     <div class="player-column">
       <AudioPlayer
+        v-if="roomId"
         ref="audioPlayer"
         :song="currentSong"
+        :roomId="roomId"
         @participants-update="updateParticipantsList"
         @update-tracks="updateTracksList"
       />
@@ -38,13 +43,16 @@ import AudioPlayer from '@/components/player.vue';
 import ParticipantsList from '@/components/Participants-list.vue';
 import TrackQueue from '@/components/Track_queue.vue';
 import SendTrack from '@/components/Send-search_Track.vue';
+import Rooms from '@/components/Rooms.vue';
+import { getCookie } from '@/utils/cookies.js';
 
 export default {
   components: {
     AudioPlayer,
     ParticipantsList,
     TrackQueue,
-    SendTrack
+    SendTrack,
+    Rooms
   },
   data() {
     return {
@@ -57,7 +65,9 @@ export default {
       currentTrackIndex: 0,
       isPlayerVisible: false,
       participants: [],
-      userId: this.getCookie('user_id'),
+      userId: getCookie('user_id'),
+      roomId: null,
+      connected: false,
       // trackUrl удален отсюда
     };
   },
@@ -65,11 +75,9 @@ export default {
     updateParticipantsList(participantsArray) {
       this.participants = participantsArray;
     },
-    getCookie(name) {
-      const value = `; ${document.cookie}`;
-      const parts = value.split(`; ${name}=`);
-      if (parts.length === 2) return parts.pop().split(';').shift();
-      return null;
+    handleJoinRoom(id) {
+      this.roomId = id;
+      this.connected = true;
     },
     updateTracksList(tracksArray, currentIndex) {
       this.tracks = tracksArray;


### PR DESCRIPTION
## Summary
- add a simple Rooms component for entering room ID
- introduce cookies and room connection utils
- update Main view to display Rooms form before connecting
- refactor player to use new utils and accept roomId prop

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6873cdf0d0ec8322905e83bdc299b6ff